### PR TITLE
Only update timer and PB when they change

### DIFF
--- a/scripts/bingo/components/timer.js
+++ b/scripts/bingo/components/timer.js
@@ -15,12 +15,12 @@ export const timer = {
 
   //Creates timer text element
   createIn(div) {
-    const span = document.createElement("span");
-    span.id = "timerString";
-    span.innerText = "Time: Click on a tile to start";
-    span.title = "Click to pause/resume";
-    span.addEventListener("click", timer.pause);
-    div.appendChild(span);
+    const timerDiv = document.createElement("div");
+    timerDiv.id = "timerString";
+    timerDiv.innerText = "Time: Click on a tile to start";
+    timerDiv.title = "Click to pause/resume";
+    timerDiv.addEventListener("click", timer.pause);
+    div.appendChild(timerDiv);
   },
 
   //Get PB from localStorage
@@ -42,7 +42,7 @@ export const timer = {
   //Called each 10 ms when timer is running
   tick() {
     const time = Date.now() - timer.startTime;
-    timer.display(time, timer.getPB());
+    timer.display(time);
   },
 
   getTime() {
@@ -64,6 +64,7 @@ export const timer = {
   start() {
     timer.startTime = Date.now();
     if (timer.state === "waiting") {
+      timer.display(timer.getTime(), timer.getPB());
       timer.tickReference = setInterval(timer.tick, 200);
       timer.state = "running";
     }
@@ -72,8 +73,7 @@ export const timer = {
   //Stops the timer
   pause() {
     if (timer.state === "won") return;
-    if (timer.state === "paused" || timer.state === "waiting")
-      return timer.resume();
+    if (timer.state === "paused" || timer.state === "waiting") return timer.resume();
     timer.pauseTime = Date.now() - timer.startTime;
     clearInterval(timer.tickReference);
     timer.tickReference = null;
@@ -86,10 +86,8 @@ export const timer = {
   resume() {
     if (timer.state === "won") return;
     if (timer.state === "waiting") return timer.start();
-    if (timer.state === "paused")
-      timer.startTime = Date.now() - timer.pauseTime;
-    if (timer.tickReference === null)
-      timer.tickReference = setInterval(timer.tick, 200);
+    if (timer.state === "paused") timer.startTime = Date.now() - timer.pauseTime;
+    if (timer.tickReference === null) timer.tickReference = setInterval(timer.tick, 200);
     const span = document.getElementById("timerString");
     span.classList.remove("paused");
     timer.state = "running";
@@ -111,22 +109,41 @@ export const timer = {
     timer.display(time, timer.getPB());
   },
 
+  // Displays the time and PB in the timer div
   display(now, pb) {
-    //Calculate current time, convert it to HH:MM:SS.MS/10 and display it
-    const span = document.getElementById("timerString");
+    const timerDiv = document.getElementById("timerString");
+    let timerSpan = document.getElementById("timerSpan");
+    let pbSpan = document.getElementById("pbSpan");
 
-    span.innerHTML = `
-      Time: 
-      ${toHours(now)}:${toMinutes(now)}:${toSeconds(now)} 
-      `;
+    const currentTimeString = `${toHours(now)}:${toMinutes(now)}:${toSeconds(now)}<br>`;
 
-    //The same with pb if exists
-    if (pb != null) {
-      span.innerHTML += `
-        <br />
-        PB:
-        ${toHours(pb)}:${toMinutes(pb)}:${toSeconds(pb)}
-       `;
-    } else span.innerHTML += "<br />PB: Not set yet";
+    let pbTimeString;
+    // This is called when the player doesn't have a PB yet
+    if (pb === null) pbTimeString = "PB: Not set yet";
+    // This is called by default, when the pb param is not set
+    else if (pb === undefined) pbTimeString = false;
+    // This is called on win, when the pb param is set and possibly changed
+    else pbTimeString = `PB: ${toHours(pb)}:${toMinutes(pb)}:${toSeconds(pb)}`;
+
+    // Called at start to create timer and pb spans
+    if (!timerSpan && !pbSpan) {
+      timerDiv.innerHTML = "";
+      timerSpan = document.createElement("span");
+      pbSpan = document.createElement("span");
+      timerSpan.id = "timerSpan";
+      pbSpan.id = "pbSpan";
+      timerDiv.appendChild(timerSpan);
+      timerDiv.appendChild(pbSpan);
+    }
+
+    // Update timer only when it has changed (every second)
+    if (timerSpan.innerHTML.indexOf(currentTimeString) === -1) {
+      timerSpan.innerHTML = `Time: ${currentTimeString}`;
+    }
+
+    // Update PB only when it has changed
+    if (pbTimeString && pbSpan.innerHTML.indexOf(pbTimeString) === -1) {
+      pbSpan.innerHTML = pbTimeString;
+    }
   },
 };


### PR DESCRIPTION
## Description

Currently, the PB and timer are calculated on every tick (200ms). The new implementation will update the timer only when it changes (every second), and update the PB when it changes (when a new PB is set)

## Changes Made

Refactored `display(time,pb)` to work with the logic described above. The `tick()` function wont pass the **pb** parameter to the `display()` function, instead, only the `start()` and `win()` functions will pass the **pb** parameter in order to update its div at the start of the game and to change the PB when the game is won (and change it if a new PB was set).

A few comments were introduced and some variables were renamed in order to make the code more readable.

## Related Issues

#14 
