### PR TITLE
fix: helperText disappearing on restore point load

### DIFF
--- a/scripts/bingo/components/history.js
+++ b/scripts/bingo/components/history.js
@@ -142,17 +142,14 @@ export const history = {
     });
 
     storedCard.slots.forEach((slot, i) => {
-      //Get string until \n is reached
-      //Because helperText is contained inside innerText and should be removed
-      let string = slot.innerText;
-      if (slot.innerText.includes("\n")) {
-        string = slot.innerText.slice(0, slot.innerText.indexOf("\n"));
-      }
+      let string = slot.innerText.split("\n")[0];
+      let helperText = slot.children[0]?.innerHTML;
 
       storedCard.slots[i] = {
         x: slot.x,
         y: slot.y,
         string: string,
+        helperText: helperText,
         selected: !!slot.classList.contains("selected"),
         win: !!slot.classList.contains("win"),
       };


### PR DESCRIPTION
## Description
fixes #34

## Changes Made
extracting and saving helperText from slot child (tooltip) 

## Related Issues
#34 

## Additional Notes
helperText was ignored on state save
